### PR TITLE
Moving Ruby for version 2.2.2 due compilation errors on version 2.0.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get install -y --force-yes build-essential wget git
 RUN apt-get install -y --force-yes zlib1g-dev libssl-dev libreadline-dev libyaml-dev libxml2-dev libxslt-dev
 RUN apt-get clean
 
-RUN wget -P /root/src ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz
-RUN cd /root/src; tar xvf ruby-2.0.0-p247.tar.gz
-RUN cd /root/src/ruby-2.0.0-p247; ./configure; make install
+RUN wget -P /root/src http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz
+RUN cd /root/src; tar xvf ruby-2.2.2.tar.gz
+RUN cd /root/src/ruby-2.2.2; ./configure; make install
 
 RUN gem update --system
 RUN gem install bundler
@@ -20,6 +20,3 @@ RUN cd /root/sinatra; bundle install
 
 EXPOSE 4567
 CMD ["/usr/local/bin/foreman","start","-d","/root/sinatra"]
-
-
-


### PR DESCRIPTION
Dockerfile modification:
Moving Ruby for version 2.2.2 due compilation errors on version 2.0.0.
